### PR TITLE
Fix .connect() method to work if window.load has already been called

### DIFF
--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -408,12 +408,16 @@
 		//Delete history and title if provided. These options should only be provided via invoke();
 		delete options.title;
 		delete options.history;
-
-		//Dont run until the window is ready.
-		internal.addEvent(window, 'load', function(){	
-			//Parse links using specified options
+		
+		if(document.readyState == 'complete') {
 			internal.parseLinks(document, options);
-		});
+		} else {
+			//Dont run until the window is ready.
+			internal.addEvent(window, 'load', function(){	
+				//Parse links using specified options
+				internal.parseLinks(document, options);
+			});
+		}
 	}
 	
 	/**


### PR DESCRIPTION
I found that pjax wasn't even initializing if `pjax.connect()` was called in a `.ready()`-like function because it waits on a load event which might have been called way earlier.
