### PR TITLE
Roll to live (v0.6.0)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "thybag/PJAX-Standalone",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "pjax-standalone.js",
   "description": "A standalone implementation of Pushstate AJAX, for non-jquery webpages.",
   "license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "thybag/PJAX-Standalone",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "main": "pjax-standalone.js",
   "description": "A standalone implementation of Pushstate AJAX, for non-jquery webpages.",
   "license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "thybag/PJAX-Standalone",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "pjax-standalone.js",
   "description": "A standalone implementation of Pushstate AJAX, for non-jquery webpages.",
   "license": "MIT",

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -148,9 +148,9 @@
 		// Attach event.
 		internal.addEvent(node, 'click', function(event){
 			// Allow middle click (pages in new windows)
-			if ( event.which > 1 || event.metaKey ) return;
+			if ( event.which > 1 || event.metaKey || event.ctrlKey ) return;
 			// Dont fire normal event
-			if(event.preventDefault){event.preventDefault();}else{event.returnValue = false;}
+			if(event.preventDefault){ event.preventDefault(); }else{ event.returnValue = false; }
 			// Take no action if we are already on said page?
 			if(document.location.href === options.url) return false;
 			// handle the load.

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -1,8 +1,8 @@
 /**
  * PJAX- Standalone
  *
- * A standalone implementation of Pushstate AJAX, for non-JQuery web pages.
- * JQuery are recommended to use the original implementation at: https://github.com/defunkt/jquery-pjax
+ * A standalone implementation of Pushstate AJAX, for non-jQuery web pages.
+ * jQuery are recommended to use the original implementation at: http://github.com/defunkt/jquery-pjax
  * 
  * @version 0.5.4
  * @author Carl
@@ -254,12 +254,19 @@
 		// Do the request
 		internal.request(options.url, function(html) {
 
+			// Fail if unable to load HTML via AJAX
+			if(html === false){
+				internal.triggerEvent(options.container,'complete', options);
+				internal.triggerEvent(options.container,'error', options);
+				return;
+			}
+
 			// Ensure we have the correct HTML to apply to our container.
 			if(options.smartLoad) html = internal.smartLoad(html, options);
 
 			// If no title was provided
 			if(typeof options.title === 'undefined'){
-				// Use current doc title (this will be updated via smartload if its enabled)
+				// Use current doc title (this will be updated via smart load if its enabled)
 				options.title = document.title;
 
 				// Attempt to grab title from non-smart loaded page contents 
@@ -290,13 +297,8 @@
 
 			// Fire Events
 			internal.triggerEvent(options.container,'complete', options);
-			if(html === false) { //Something went wrong
-				internal.triggerEvent(options.container,'error', options);
-				return;
-			} else {//got what we expected.
-				internal.triggerEvent(options.container,'success', options);
-			}
-
+			internal.triggerEvent(options.container,'success', options);
+			
 			// Don't track if page isn't part of history, or if autoAnalytics is disabled
 			if(options.autoAnalytics && options.history) {
 				// If autoAnalytics is enabled and a Google analytics tracker is detected push 

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -280,6 +280,8 @@
 			// If Google analytics is detected push a trackPageView, so PJAX pages can 
 			// be tracked successfully.
 			if(window._gaq) _gaq.push(['_trackPageview']);
+			if(window.ga) ga('send', 'pageview', {'page': options.url, 'title': options.title});
+
 
 			// Set new title
 			document.title = options.title;

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -4,7 +4,7 @@
  * A standalone implementation of Pushstate AJAX, for non-JQuery web pages.
  * JQuery are recommended to use the original implementation at: https://github.com/defunkt/jquery-pjax
  * 
- * @version 0.5.3
+ * @version 0.5.4
  * @author Carl
  * @source https://github.com/thybag/PJAX-Standalone
  * @license MIT
@@ -50,7 +50,7 @@
 	 * @param event Event to listen for.
 	 * @param callback Method to run when event is detected.
 	 */
-	internal.addEvent = function(obj, event, callback){
+	internal.addEvent = function(obj, event, callback) {
 		obj.addEventListener(event, callback, false);
 	};
 
@@ -63,7 +63,7 @@
 	 * @param obj
 	 * @return obj
 	 */
-	internal.clone = function(obj){
+	internal.clone = function(obj) {
 		object = {};
 		// For every option in object, create it in the duplicate.
 		for (var i in obj) {
@@ -80,7 +80,7 @@
 	 * @param node. Objects to fire event on
 	 * @return event_name. type of event
 	 */
-	internal.triggerEvent = function(node, event_name, data){
+	internal.triggerEvent = function(node, event_name, data) {
 		// Good browsers
 		evt = document.createEvent("HTMLEvents");
 		evt.initEvent(event_name, true, true);
@@ -93,7 +93,7 @@
 	 * popstate listener
 	 * Listens for back/forward button events and updates page accordingly.
 	 */
-	internal.addEvent(window, 'popstate', function(st){
+	internal.addEvent(window, 'popstate', function(st) {
 		if(st.state !== null) {
 
 			var opt = {	
@@ -184,9 +184,9 @@
 		}
 
 		// For all returned nodes
-		for(var i=0,tmp_opt; i < nodes.length; i++){
+		for(var i=0,tmp_opt; i < nodes.length; i++) {
 			node = nodes[i];
-			if(typeof options.excludeClass !== 'undefined'){
+			if(typeof options.excludeClass !== 'undefined') {
 				if(node.className.indexOf(options.excludeClass) !== -1) continue;
 			}
 			// Override options history to true, else link parsing could be triggered by back button (which runs in no-history mode)
@@ -225,7 +225,7 @@
 
 		// Look through all returned divs.
 		tmpNodes = tmp.getElementsByTagName('div');
-		for(var i=0;i<tmpNodes.length;i++){
+		for(var i=0;i<tmpNodes.length;i++) {
 			if(tmpNodes[i].id === options.container.id){
 				// If our container div is within the returned HTML, we both know the returned content is
 				// not PJAX ready, but instead likely the full HTML content. in Addition we can also guess that
@@ -246,7 +246,7 @@
 	 * @param node. Dom node to add returned content in to.
 	 * @param addtohistory. Does this load require a history event.
 	 */
-	internal.handle = function(options){
+	internal.handle = function(options) {
 		
 		// Fire beforeSend Event.
 		internal.triggerEvent(options.container, 'beforeSend', options);
@@ -265,7 +265,7 @@
 				// Attempt to grab title from non-smart loaded page contents 
 				if(!options.smartLoad){
 					var tmpTitle = options.container.getElementsByTagName('title');
-					if(tmpTitle.length !== 0) options.title = tmpTitle[0].innerHTML
+					if(tmpTitle.length !== 0) options.title = tmpTitle[0].innerHTML;
 				}
 			}
 
@@ -309,7 +309,7 @@
 			document.title = options.title;
 
 			// Scroll page to top on new page load
-			if(options.returnToTop){
+			if(options.returnToTop) {
 				window.scrollTo(0, 0);
 			} 
 		});
@@ -323,27 +323,33 @@
 	 * @param location. Page to request.
 	 * @param callback. Method to call when a page is loaded.
 	 */
-	internal.request = function(location, callback){
+	internal.request = function(location, callback) {
 		// Create xmlHttpRequest object.
-		try {var xmlhttp = window.XMLHttpRequest?new XMLHttpRequest(): new ActiveXObject("Microsoft.XMLHTTP");}  catch (e) { }
-			// Add state listener.
-			xmlhttp.onreadystatechange = function(){
-				if ((xmlhttp.readyState === 4) && (xmlhttp.status === 200)) {
-					// Success, Return HTML
-					callback(xmlhttp.responseText);
-				}else if((xmlhttp.readyState === 4) && (xmlhttp.status === 404 || xmlhttp.status === 500)){
-					// error (return false)
-					callback(false);
-				}
-			};
-			// Secret pjax ?get param so browser doesn't return pjax content from cache when we don't want it to
-			// Switch between ? and & so as not to break any URL params (Based on change by zmasek https://github.com/zmasek/)
-			xmlhttp.open("GET", location + ((!/[?&]/.test(location)) ? '?_pjax' : '&_pjax'), true);
-			// Add headers so things can tell the request is being performed via AJAX.
-			xmlhttp.setRequestHeader('X-PJAX', 'true'); // PJAX header
-			xmlhttp.setRequestHeader('X-Requested-With', 'XMLHttpRequest');// Standard AJAX header.
+		var xmlhttp;
+		try { 
+			xmlhttp = window.XMLHttpRequest? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"); 
+		}  catch (e) { 
+			console.log("Unable to create XMLHTTP Request");
+			return; 
+		}
+		// Add state listener.
+		xmlhttp.onreadystatechange = function() {
+			if ((xmlhttp.readyState === 4) && (xmlhttp.status === 200)) {
+				// Success, Return HTML
+				callback(xmlhttp.responseText);
+			}else if((xmlhttp.readyState === 4) && (xmlhttp.status === 404 || xmlhttp.status === 500)){
+				// error (return false)
+				callback(false);
+			}
+		};
+		// Secret pjax ?get param so browser doesn't return pjax content from cache when we don't want it to
+		// Switch between ? and & so as not to break any URL params (Based on change by zmasek https://github.com/zmasek/)
+		xmlhttp.open("GET", location + ((!/[?&]/.test(location)) ? '?_pjax' : '&_pjax'), true);
+		// Add headers so things can tell the request is being performed via AJAX.
+		xmlhttp.setRequestHeader('X-PJAX', 'true'); // PJAX header
+		xmlhttp.setRequestHeader('X-Requested-With', 'XMLHttpRequest');// Standard AJAX header.
 
-			xmlhttp.send(null);
+		xmlhttp.send(null);
 	};
 
 	/**
@@ -354,7 +360,7 @@
 	 * @param options
 	 * @return false | valid options object
 	 */
-	internal.parseOptions = function(options){
+	internal.parseOptions = function(options) {
 
 		/**  Defaults parse options. (if something isn't provided)
 		 *
@@ -412,16 +418,16 @@
 	 * @param container - (string) container ID | container DOM node.
 	 * @return container DOM node | false
 	 */
-	internal.get_container_node = function(container){
+	internal.get_container_node = function(container) {
 		if(typeof container === 'string') {
-			var container = document.getElementById(container);
+			container = document.getElementById(container);
 			if(container === null){
 				console.log("Could not find container with id:" + container);
 				return false;
 			}
 		}
 		return container;
-	}
+	};
 
 	/**
 	 * connect
@@ -445,7 +451,7 @@
 	 *					})
 	 *		Will use the provided JSON to configure the script in full (including callbacks)
 	 */
-	this.connect = function(/* options */){
+	this.connect = function(/* options */) {
 		// connect();
 		var options = {};
 		// connect(container, class_to_apply_to)
@@ -487,7 +493,7 @@
 	 * @scope public
 	 * @param options  
 	 */
-	this.invoke = function(/* options */){
+	this.invoke = function(/* options */) {
 		// url, container
 		if(arguments.length === 2){
 			options = {};

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -173,7 +173,7 @@
 	 * @param options. Valid Options object.
 	 */
 	internal.parseLinks = function(dom_obj, options) {
-		if(typeof options.useClass != 'undefined'){
+		if(typeof options.useClass !== 'undefined'){
 			// Get all nodes with the provided class name.
 			nodes = dom_obj.getElementsByClassName(options.useClass);
 		}else{
@@ -183,6 +183,9 @@
 		// For all returned nodes
 		for(var i=0,tmp_opt; i < nodes.length; i++){
 			node = nodes[i];
+			if(typeof options.excludeClass !== 'undefined'){
+				if(node.className.indexOf(options.excludeClass) !== -1) continue;
+			}
 			// Override options history to true, else link parsing could be triggered by back button (which runs in no-history mode)
 			tmp_opt = internal.clone(options);
 			tmp_opt.history = true;
@@ -315,7 +318,7 @@
 	 */
 	internal.request = function(location, callback){
 		// Create xmlHttpRequest object.
-		try {xmlhttp = window.XMLHttpRequest?new XMLHttpRequest(): new ActiveXObject("Microsoft.XMLHTTP");}  catch (e) { }
+		try {var xmlhttp = window.XMLHttpRequest?new XMLHttpRequest(): new ActiveXObject("Microsoft.XMLHTTP");}  catch (e) { }
 			// Add state listener.
 			xmlhttp.onreadystatechange = function(){
 				if ((xmlhttp.readyState === 4) && (xmlhttp.status === 200)) {
@@ -422,7 +425,7 @@
 	 *						'container':'somecontainer',
 	 *						'beforeSend': function(){console.log("sending");}
 	 *					})
-	 *		Will use the provided json to configure the script in full (including callbacks)
+	 *		Will use the provided JSON to configure the script in full (including callbacks)
 	 */
 	this.connect = function(/* options */){
 		// connect();
@@ -432,7 +435,7 @@
 			options.container = arguments[0];
 			options.useClass = arguments[1];
 		}
-		// Either json or container id
+		// Either JSON or container id
 		if(arguments.length === 1){
 			if(typeof arguments[0] === 'string' ) {
 				//connect(container_id)
@@ -450,7 +453,7 @@
 		if(document.readyState === 'complete') {
 			internal.parseLinks(document, options);
 		} else {
-			//Dont run until the window is ready.
+			//Don't run until the window is ready.
 			internal.addEvent(window, 'load', function(){	
 				//Parse links using specified options
 				internal.parseLinks(document, options);

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -28,10 +28,10 @@
 		var pjax_shell = {
 			"connect": function() { return; },
 			"invoke": function() {
-		 		var url = (arguments.length === 2) ? arguments[0] : arguments.url;
-		 		document.location = url;
+				var url = (arguments.length === 2) ? arguments[0] : arguments.url;
+				document.location = url;
 				return;	
-		 	} 
+			} 
 		};
 		// amd support
 		if (typeof define === 'function' && define.amd) { 
@@ -355,7 +355,7 @@
 			options.history = opt.history;
 		}else{
 			// Ensure its bool.
-			options.history = (!(options.history === false));
+			options.history = (options.history === false) ? false : true;
 		}
 
 		// Parse Links on load? Enabled by default.

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -1,8 +1,8 @@
 /**
  * PJAX- Standalone
  *
- * A standalone implementation of Pushstate AJAX, for non-JQuery webpages.
- * JQuery users should use the original implimention at: https://github.com/defunkt/jquery-pjax
+ * A standalone implementation of Pushstate AJAX, for non-JQuery web pages.
+ * JQuery are recommended to use the original implementation at: https://github.com/defunkt/jquery-pjax
  * 
  * @version 0.5.3
  * @author Carl

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -4,7 +4,7 @@
  * A standalone implementation of Pushstate AJAX, for non-JQuery webpages.
  * JQuery users should use the original implimention at: https://github.com/defunkt/jquery-pjax
  * 
- * @version 0.5.2
+ * @version 0.5.3
  * @author Carl
  * @source https://github.com/thybag/PJAX-Standalone
  * @license MIT
@@ -238,15 +238,7 @@
 
 			// Ensure we have the correct HTML to apply to our container.
 			if(options.smartLoad) html = internal.smartLoad(html, options);
-			
-			// Update the dom with the new content
-			options.container.innerHTML = html;
 
-			// Initalise any links found within document (if enabled).
-			if(options.parseLinksOnload){
-				internal.parseLinks(options.container, options);
-			}
-			
 			// If no title was provided
 			if(typeof options.title === 'undefined'){
 				// Attempt to grab title from page contents.
@@ -256,6 +248,9 @@
 					options.title = document.title;
 				}
 			}
+
+			// Update the dom with the new content
+			options.container.innerHTML = html;
 			
 			// Do we need to add this to the history?
 			if(options.history){
@@ -266,6 +261,11 @@
 				}
 				// Update browser history
 				window.history.pushState({'url': options.url, 'container': options.container.id }, options.title , options.url);
+			}
+
+			// Initalise any new links found within document (if enabled).
+			if(options.parseLinksOnload){
+				internal.parseLinks(options.container, options);
 			}
 
 			// Fire Events

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -4,7 +4,7 @@
  * A standalone implementation of Pushstate AJAX, for non-jQuery web pages.
  * jQuery are recommended to use the original implementation at: http://github.com/defunkt/jquery-pjax
  * 
- * @version 0.5.4
+ * @version 0.6.0
  * @author Carl
  * @source https://github.com/thybag/PJAX-Standalone
  * @license MIT

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -336,50 +336,39 @@
 	 * @return false | valid options object
 	 */
 	internal.parseOptions = function(options){
-		// Defaults. (if something isn't provided)
-		opt = {};
-		opt.history = true;
-		opt.parseLinksOnload = true;
-		opt.smartLoad = true;
-		opt.autoAnalytics = true;
 
-		// Ensure a url and container have been provided.
-		if(typeof options.url === 'undefined' || typeof options.container === 'undefined'){
+		/**  Defaults parse options. (if something isn't provided)
+		 *
+		 * - history: track event to history (on by default, set to off when performing back operation)
+		 * - parseLinksOnload: Enabled by default. Process pages loaded via PJAX and setup PJAX on any links found.
+		 * - smartLoad: Tries to ensure the correct HTML is loaded. If you are certain your back end 
+		 *		will only return PJAX ready content this can be disabled for a slight performance boost.
+		 * - autoAnalytics: Automatically attempt to log events to google analytics (if tracker is available)
+		 */
+		var defaults = {
+			"history": true,
+			"parseLinksOnload": true,
+			"smartLoad" : true,
+			"autoAnalytics": true
+		};
+
+		// Ensure a URL and container have been provided.
+		if(typeof options.url === 'undefined' || typeof options.container === 'undefined' || options.container === null) {
 			console.log("URL and Container must be provided.");
 			return false;
 		}
 
-		// Find out if history has been provided
-		if(typeof options.history === 'undefined'){
-			// use default
-			options.history = opt.history;
-		}else{
-			// Ensure its bool.
-			options.history = (options.history === false) ? false : true;
+		// Check required options are defined, if not, use default
+		for(var o in defaults) {
+			if(typeof options[o] === 'undefined') options[o] = defaults[o];
 		}
 
-		// Parse Links on load? Enabled by default.
-		// (Process pages loaded via PJAX and setup PJAX on any links found.)
-		if(typeof options.parseLinksOnload === 'undefined'){
-			options.parseLinksOnload = opt.parseLinksOnload;
-		}
+		// Ensure history setting is a boolean.
+		options.history = (options.history === false) ? false : true;
 
-		// Smart load (enabled by default.) Tries to ensure the correct HTML is loaded.
-		// If you are certain your back end will only return PJAX ready content this can be disabled
-		// for a slight performance boost.
-		if(typeof options.smartLoad === 'undefined'){
-			options.smartLoad = opt.smartLoad;
-		}
-
-		// Automatically attempt to log events to google analytics (if tracker is available)
-		// set autoAnalytics to false to disable
-		if(typeof options.autoAnalytics === 'undefined'){
-			options.autoAnalytics = opt.autoAnalytics;
-		}
-
-		// Get container (if its an id, convert it to a dom node.)
-		if(typeof options.container === 'string' ) {
-			container = document.getElementById(options.container);
+		// Get container (if its an id, convert it to a DOM node.)
+		if(typeof options.container === 'string') {
+			var container = document.getElementById(options.container);
 			if(container === null){
 				console.log("Could not find container with id:"+options.container);
 				return false;
@@ -387,19 +376,17 @@
 			options.container = container;
 		}
 
-		// If everything went ok thus far, connect up listeners
-		if(typeof options.beforeSend === 'function'){
-			internal.addEvent(options.container, 'beforeSend', options.beforeSend);
+		// Events
+		var events = ['beforeSend', 'complete', 'error', 'success'];
+
+		// If everything went okay thus far, connect up listeners
+		for(var e in events){
+			var evt = events[e];
+			if(typeof options[evt] === 'function'){
+				internal.addEvent(options.container, evt, options[evt]);
+			}
 		}
-		if(typeof options.complete === 'function'){
-			internal.addEvent(options.container, 'complete', options.complete);
-		}
-		if(typeof options.error === 'function'){
-			internal.addEvent(options.container, 'error', options.error);
-		}
-		if(typeof options.success === 'function'){
-			internal.addEvent(options.container, 'success', options.success);
-		}
+
 		// Return valid options
 		return options;
 	};

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -13,7 +13,7 @@
 
 	// Object to store private values/methods.
 	var internal = {
-		// Is this the first usage of pjax? (Ensure history entery has required values if so.)
+		// Is this the first usage of pjax? (Ensure history entry has required values if so.)
 		"firstrun": true,
 		// Borrowed wholesale from https://github.com/defunkt/jquery-pjax
 		// Attempt to check that a device supports pushstate before attempting to use it.
@@ -21,8 +21,8 @@
 	};
 	
 	// If PJAX isn't supported we can skip setting up the library all together
-	// So as not to break any code expecing pjax to be there, return a shell object containing
-	// IE7 + compatable versions of connect (which needs to do nothing) and invoke ( which just changes the page)
+	// So as not to break any code expecting pjax to be there, return a shell object containing
+	// IE7 + compatible versions of connect (which needs to do nothing) and invoke ( which just changes the page)
 	if(!internal.is_supported) {
 		// Pjax shell, so any code expecting pjax will work
 		var pjax_shell = {
@@ -56,8 +56,8 @@
 
 	/**
 	 * Clone
-	 * Util method to create copys of the options object (so they do not share references)
-	 * This allows custom settings on differnt links.
+	 * Util method to create copies of the options object (so they do not share references)
+	 * This allows custom settings on different links.
 	 *
 	 * @scope private
 	 * @param obj
@@ -110,7 +110,7 @@
 
 			// Convert state data to pjax options
 			var options = internal.parseOptions(opt);
-			// If somthing went wrong, return.
+			// If something went wrong, return.
 			if(options === false) return;
 			// If there is a state object, handle it as a page load.
 			internal.handle(options);
@@ -124,11 +124,11 @@
 	 * @param link_node. link that will be clicked.
 	 * @param content_node. 
 	 */
-	internal.attach = function(node, options){
+	internal.attach = function(node, options) {
 
 		// Ignore external links.
 		if ( node.protocol !== document.location.protocol ||
-			node.host !== document.location.host ){
+			node.host !== document.location.host ) {
 			return;
 		}
 
@@ -140,11 +140,11 @@
 		// Add link href to object
 		options.url = node.href;
 		// If pjax data is specified, use as container
-		if(node.getAttribute('data-pjax')){
+		if(node.getAttribute('data-pjax')) {
 			options.container = node.getAttribute('data-pjax');
 		}
 		// If data-title is specified, use as title.
-		if(node.getAttribute('data-title')){
+		if(node.getAttribute('data-title')) {
 			options.title = node.getAttribute('data-title');
 		}
 		// Check options are valid.
@@ -152,7 +152,7 @@
 		if(options === false) return;
 
 		// Attach event.
-		internal.addEvent(node, 'click', function(event){
+		internal.addEvent(node, 'click', function(event) {
 			// Allow middle click (pages in new windows)
 			if ( event.which > 1 || event.metaKey || event.ctrlKey ) return;
 			// Dont fire normal event
@@ -166,14 +166,14 @@
 
 	/**
 	 * parseLinks
-	 * Parse all links within a dom node, using settings provided in options.
+	 * Parse all links within a DOM node, using settings provided in options.
 	 * @scope private
 	 * @param dom_obj. Dom node to parse for links.
 	 * @param options. Valid Options object.
 	 */
-	internal.parseLinks = function(dom_obj, options){
+	internal.parseLinks = function(dom_obj, options) {
 		if(typeof options.useClass != 'undefined'){
-			// Get all nodes with the provided classname.
+			// Get all nodes with the provided class name.
 			nodes = dom_obj.getElementsByClassName(options.useClass);
 		}else{
 			// If no class was provided, just get all the links
@@ -182,7 +182,7 @@
 		// For all returned nodes
 		for(var i=0,tmp_opt; i < nodes.length; i++){
 			node = nodes[i];
-			// Override options history to true, else link parsing could be triggered by backbutton (which runs in no-history mode)
+			// Override options history to true, else link parsing could be triggered by back button (which runs in no-history mode)
 			tmp_opt = internal.clone(options);
 			tmp_opt.history = true;
 			internal.attach(node, tmp_opt);
@@ -193,18 +193,18 @@
 	 * SmartLoad
 	 * Smartload checks the returned HTML to ensure PJAX ready content has been provided rather than
 	 * a full HTML page. If a full HTML has been returned, it will attempt to scan the page and extract
-	 * the correct html to update our container with in order to ensure PJAX still functions as expected.
+	 * the correct HTML to update our container with in order to ensure PJAX still functions as expected.
 	 *
 	 * @scope private
-	 * @param html (HTML returned from AJAX)
+	 * @param HTML (HTML returned from AJAX)
 	 * @param options (Options object used to request page)
 	 * @return HTML to append to our page.
 	 */
-	internal.smartLoad = function(html, options){
+	internal.smartLoad = function(html, options) {
 		// Create tmp node (So we can interact with it via the DOM)
 		var tmp = document.createElement('div');
-		
-		// Add html
+
+		// Add HTML
 		tmp.innerHTML = html; 
 
 		// Grab the title if there is one
@@ -241,7 +241,7 @@
 		internal.triggerEvent(options.container, 'beforeSend', options);
 
 		// Do the request
-		internal.request(options.url, function(html){
+		internal.request(options.url, function(html) {
 
 			// Ensure we have the correct HTML to apply to our container.
 			if(options.smartLoad) html = internal.smartLoad(html, options);
@@ -256,11 +256,11 @@
 				}
 			}
 
-			// Update the dom with the new content
+			// Update the DOM with the new content
 			options.container.innerHTML = html;
 			
 			// Do we need to add this to the history?
-			if(options.history){
+			if(options.history) {
 				// If this is the first time pjax has run, create a state object for the current page.
 				if(internal.firstrun){
 					window.history.replaceState({'url': document.location.href, 'container':  options.container.id}, document.title);
@@ -270,25 +270,27 @@
 				window.history.pushState({'url': options.url, 'container': options.container.id }, options.title , options.url);
 			}
 
-			// Initalise any new links found within document (if enabled).
+			// Initialize any new links found within document (if enabled).
 			if(options.parseLinksOnload){
 				internal.parseLinks(options.container, options);
 			}
 
 			// Fire Events
 			internal.triggerEvent(options.container,'complete', options);
-			if(html === false){//Somthing went wrong
+			if(html === false) { //Something went wrong
 				internal.triggerEvent(options.container,'error', options);
 				return;
-			}else{//got what we expected.
+			} else {//got what we expected.
 				internal.triggerEvent(options.container,'success', options);
 			}
 
-			// If Google analytics is detected push a trackPageView, so PJAX pages can 
-			// be tracked successfully.
-			if(window._gaq) _gaq.push(['_trackPageview']);
-			if(window.ga) ga('send', 'pageview', {'page': options.url, 'title': options.title});
-
+			// Don't track if page isn't part of history, or if autoAnalytics is disabled
+			if(options.autoAnalytics && options.history) {
+				// If autoAnalytics is enabled and a Google analytics tracker is detected push 
+				// a trackPageView, so PJAX loaded pages can be tracked successfully.
+				if(window._gaq) _gaq.push(['_trackPageview']);
+				if(window.ga) ga('send', 'pageview', {'page': options.url, 'title': options.title});
+			}
 			// Set new title
 			document.title = options.title;
 		});
@@ -308,14 +310,14 @@
 			// Add state listener.
 			xmlhttp.onreadystatechange = function(){
 				if ((xmlhttp.readyState === 4) && (xmlhttp.status === 200)) {
-					// Success, Return html
+					// Success, Return HTML
 					callback(xmlhttp.responseText);
 				}else if((xmlhttp.readyState === 4) && (xmlhttp.status === 404 || xmlhttp.status === 500)){
 					// error (return false)
 					callback(false);
 				}
 			};
-			// Secret pjax ?get param so browser doesnt return pjax content from cache when we dont want it to
+			// Secret pjax ?get param so browser doesn't return pjax content from cache when we don't want it to
 			// Switch between ? and & so as not to break any URL params (Based on change by zmasek https://github.com/zmasek/)
 			xmlhttp.open("GET", location + ((!/[?&]/.test(location)) ? '?_pjax' : '&_pjax'), true);
 			// Add headers so things can tell the request is being performed via AJAX.
@@ -334,11 +336,12 @@
 	 * @return false | valid options object
 	 */
 	internal.parseOptions = function(options){
-		// Defaults. (if somthing isn't provided)
+		// Defaults. (if something isn't provided)
 		opt = {};
 		opt.history = true;
 		opt.parseLinksOnload = true;
 		opt.smartLoad = true;
+		opt.autoAnalytics = true;
 
 		// Ensure a url and container have been provided.
 		if(typeof options.url === 'undefined' || typeof options.container === 'undefined'){
@@ -356,16 +359,22 @@
 		}
 
 		// Parse Links on load? Enabled by default.
-		// (Proccess pages loaded via PJAX and setup PJAX on any links found.)
+		// (Process pages loaded via PJAX and setup PJAX on any links found.)
 		if(typeof options.parseLinksOnload === 'undefined'){
 			options.parseLinksOnload = opt.parseLinksOnload;
 		}
 
-		// Smart load (enabled by default.) Trys to ensure the correct HTML is loaded.
-		// If you are certain your backend will only return PJAX ready content this can be disabled
-		// for a slight perfomance boost.
+		// Smart load (enabled by default.) Tries to ensure the correct HTML is loaded.
+		// If you are certain your back end will only return PJAX ready content this can be disabled
+		// for a slight performance boost.
 		if(typeof options.smartLoad === 'undefined'){
 			options.smartLoad = opt.smartLoad;
+		}
+
+		// Automatically attempt to log events to google analytics (if tracker is available)
+		// set autoAnalytics to false to disable
+		if(typeof options.autoAnalytics === 'undefined'){
+			options.autoAnalytics = opt.autoAnalytics;
 		}
 
 		// Get container (if its an id, convert it to a dom node.)
@@ -408,7 +417,7 @@
 	 *		Will try to attach to all links, using the container_id as the target.
 	 *
 	 * Calling as connect(container_id, class_name)
-	 *		Will try to attach any links with the given classname, using container_id as the target.
+	 *		Will try to attach any links with the given class name, using container_id as the target.
 	 *
 	 * Calling as connect({	
 	 *						'url':'somepage.php',
@@ -469,13 +478,13 @@
 			options = arguments[0];
 		}
 
-		// Proccess options
+		// Process options
 		options = internal.parseOptions(options);
-		// If everything went ok, activate pjax.
+		// If everything went okay, activate pjax.
 		if(options !== false) internal.handle(options);
 	};
 
-	// Make object useable
+	// Make object usable
 	var pjax_obj = this;
 	if (typeof define === 'function' && define.amd) {
 		// Register pjax as AMD module
@@ -483,7 +492,7 @@
 			return pjax_obj;
 		});
 	}else{
-		// Make PJAX object accessible in global namespace
+		// Make PJAX object accessible in global name space
 		window.pjax = pjax_obj;
 	}
 

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -11,12 +11,12 @@
  */
 (function(){
 
-	//Object to store private values/methods.
+	// Object to store private values/methods.
 	var internal = {
-		//Is this the first usage of pjax? (Ensure history entery has required values if so.)
+		// Is this the first usage of pjax? (Ensure history entery has required values if so.)
 		"firstrun": true,
-		//Borrowed wholesale from https://github.com/defunkt/jquery-pjax
-		//Attempt to check that a device supports pushstate before attempting to use it.
+		// Borrowed wholesale from https://github.com/defunkt/jquery-pjax
+		// Attempt to check that a device supports pushstate before attempting to use it.
 		"is_supported": window.history && window.history.pushState && window.history.replaceState && !navigator.userAgent.match(/((iPod|iPhone|iPad).+\bOS\s+[1-4]|WebApps\/.+CFNetwork)/)
 	};
 	
@@ -31,13 +31,13 @@
 	 */
 	internal.addEvent = function(obj, event, callback){
 		if(window.addEventListener){
-				//Browsers that don't suck
+				// Browsers that don't suck
 				obj.addEventListener(event, callback, false);
 		}else{
-				//IE8/7
+				// IE8/7
 				obj.attachEvent('on'+event, callback);
 		}
-	}
+	};
 
 	/**
 	 * Clone
@@ -50,12 +50,12 @@
 	 */
 	internal.clone = function(obj){
 		object = {};
-		//For every option in object, create it in the duplicate.
+		// For every option in object, create it in the duplicate.
 		for (var i in obj) {
 			object[i] = obj[i];
 		}
 		return object;
-	}
+	};
 
 	/**
 	 * triggerEvent
@@ -67,42 +67,43 @@
 	 */
 	internal.triggerEvent = function(node, event_name){
 		if (document.createEvent) {
-			//Good browsers
+			// Good browsers
 			evt = document.createEvent("HTMLEvents");
-    		evt.initEvent(event_name, true, true);
-    		node.dispatchEvent(evt);
+			evt.initEvent(event_name, true, true);
+			node.dispatchEvent(evt);
 		}else{
-			//old IE versions
+			// old IE versions
 			evt = document.createEventObject();
-    		evt.eventType = 'on'+ event_name;
-    		node.fireEvent(evt.eventType, evt);
+			evt.eventType = 'on'+ event_name;
+			node.fireEvent(evt.eventType, evt);
 		}
-	}
+	};
+
 	/**
 	 * popstate listener
 	 * Listens for back/forward button events and updates page accordingly.
 	 */
 	internal.addEvent(window, 'popstate', function(st){
-		if(st.state != null){
+		if(st.state !== null) {
 
 			var opt = {	
 				'url': st.state.url, 
 				'container': st.state.container, 
 				'history': false
-			}
+			};
 
 			// Merge original in original connect options
 			if(typeof internal.options !== 'undefined'){
 				for(var a in internal.options){ 
 					if(typeof opt[a] === 'undefined') opt[a] = internal.options[a];
-				} 	
+				}
 			}
 
-			//Convert state data to pjax options
+			// Convert state data to pjax options
 			var options = internal.parseOptions(opt);
-			//If somthing went wrong, return.
-			if(options == false) return;
-			//If there is a state object, handle it as a page load.
+			// If somthing went wrong, return.
+			if(options === false) return;
+			// If there is a state object, handle it as a page load.
 			internal.handle(options);
 		}
 	});
@@ -121,14 +122,14 @@
 
 		// Ignore external links.
 		if ( node.protocol !== document.location.protocol ||
-			 node.host !== document.location.host ){
+			node.host !== document.location.host ){
 			return;
 		}
 
 		// Ignore anchors on the same page
-		if(node.pathname == location.pathname && node.hash.length > 0) {
-	 		return true
-	 	}
+		if(node.pathname === location.pathname && node.hash.length > 0) {
+			return true;
+		}
 
 		// Add link href to object
 		options.url = node.href;
@@ -142,20 +143,21 @@
 		}
 		// Check options are valid.
 		options = internal.parseOptions(options);
-		if(options == false) return;
+		if(options === false) return;
 
 		// Attach event.
 		internal.addEvent(node, 'click', function(event){
-			//Allow middle click (pages in new windows)
+			// Allow middle click (pages in new windows)
 			if ( event.which > 1 || event.metaKey ) return;
-			//Dont fire normal event
+			// Dont fire normal event
 			if(event.preventDefault){event.preventDefault();}else{event.returnValue = false;}
-			//Take no action if we are already on said page?
-			if(document.location.href == options.url) return false;
-			//handle the load.
+			// Take no action if we are already on said page?
+			if(document.location.href === options.url) return false;
+			// handle the load.
 			internal.handle(options);
 		});
-	}
+	};
+
 	/**
 	 * parseLinks
 	 * Parse all links within a dom node, using settings provided in options.
@@ -165,26 +167,27 @@
 	 */
 	internal.parseLinks = function(dom_obj, options){
 		if(typeof options.useClass != 'undefined'){
-			//Get all nodes with the provided classname.
+			// Get all nodes with the provided classname.
 			nodes = dom_obj.getElementsByClassName(options.useClass);
 		}else{
-			//If no class was provided, just get all the links
+			// If no class was provided, just get all the links
 			nodes = dom_obj.getElementsByTagName('a');
 		}
-		//For all returned nodes
+		// For all returned nodes
 		for(var i=0,tmp_opt; i < nodes.length; i++){
 			node = nodes[i];
-			//Override options history to true, else link parsing could be triggered by backbutton (which runs in no-history mode)
+			// Override options history to true, else link parsing could be triggered by backbutton (which runs in no-history mode)
 			tmp_opt = internal.clone(options);
 			tmp_opt.history = true;
 			internal.attach(node, tmp_opt);
 		}
-	}
+	};
+
 	/**
 	 * SmartLoad
 	 * Smartload checks the returned HTML to ensure PJAX ready content has been provided rather than
-     * a full HTML page. If a full HTML has been returned, it will attempt to scan the page and extract
-     * the correct html to update our container with in order to ensure PJAX still functions as expected.
+	 * a full HTML page. If a full HTML has been returned, it will attempt to scan the page and extract
+	 * the correct html to update our container with in order to ensure PJAX still functions as expected.
 	 *
 	 * @scope private
 	 * @param html (HTML returned from AJAX)
@@ -192,31 +195,30 @@
 	 * @return HTML to append to our page.
 	 */
 	internal.smartLoad = function(html, options){
-		//Create tmp node (So we can interact with it via the DOM)
+		// Create tmp node (So we can interact with it via the DOM)
 		var tmp = document.createElement('div');
-		//Add html
+		// Add html
 		tmp.innerHTML = html; 
 
-        // Grab the title if there is one (maintain IE7 compatability)
-	    var title = tmp.getElementsByTagName('title')[0].innerHTML;
-	    if(title)
-           document.title = title;
+		// Grab the title if there is one (maintain IE7 compatability)
+		var title = tmp.getElementsByTagName('title')[0].innerHTML;
+		if(title)
+			document.title = title;
 
 		// Look through all returned divs.
 		tmpNodes = tmp.getElementsByTagName('div');
 		for(var i=0;i<tmpNodes.length;i++){
-			if(tmpNodes[i].id == options.container.id){
+			if(tmpNodes[i].id === options.container.id){
 				// If our container div is within the returned HTML, we both know the returned content is
 				// not PJAX ready, but instead likely the full HTML content. in Addition we can also guess that
 				// the content of this node is what we want to update our container with.
 				// Thus use this content as the HTML to append in to our page via PJAX.
 				return tmpNodes[i].innerHTML; 
-				break;
 			}
 		}
 		// If our container was not found, HTML will be returned as is.
 		return html;
-	}
+	};
 
 	/**
 	 * handle
@@ -228,62 +230,61 @@
 	 */
 	internal.handle = function(options){
 		
-		//Fire beforeSend Event.
+		// Fire beforeSend Event.
 		internal.triggerEvent(options.container, 'beforeSend');
 
-		//Do the request
+		// Do the request
 		internal.request(options.url, function(html){
 
-			//Ensure we have the correct HTML to apply to our container.
+			// Ensure we have the correct HTML to apply to our container.
 			if(options.smartLoad) html = internal.smartLoad(html, options);
 			
-			//Update the dom with the new content
+			// Update the dom with the new content
 			options.container.innerHTML = html;
 
-			//Initalise any links found within document (if enabled).
+			// Initalise any links found within document (if enabled).
 			if(options.parseLinksOnload){
 				internal.parseLinks(options.container, options);
 			}
 			
-			//If no title was provided
-			if(typeof options.title == 'undefined'){
+			// If no title was provided
+			if(typeof options.title === 'undefined'){
 				// Attempt to grab title from page contents.
-				if(options.container.getElementsByTagName('title').length != 0){
+				if(options.container.getElementsByTagName('title').length !== 0){
 					options.title = options.container.getElementsByTagName('title')[0].innerHTML;
 				}else{
 					options.title = document.title;
 				}
 			}
 			
-			//Do we need to add this to the history?
+			// Do we need to add this to the history?
 			if(options.history){
-				//If this is the first time pjax has run, create a state object for the current page.
+				// If this is the first time pjax has run, create a state object for the current page.
 				if(internal.firstrun){
 					window.history.replaceState({'url': document.location.href, 'container':  options.container.id}, document.title);
 					internal.firstrun = false;
 				}
-				//Update browser history
+				// Update browser history
 				window.history.pushState({'url': options.url, 'container': options.container.id }, options.title , options.url);
 			}
 
-			//Fire Events
+			// Fire Events
 			internal.triggerEvent(options.container,'complete');
-			if(html == false){//Somthing went wrong
+			if(html === false){//Somthing went wrong
 				internal.triggerEvent(options.container,'error');
 				return;
 			}else{//got what we expected.
 				internal.triggerEvent(options.container,'success');
 			}
 
-			//If Google analytics is detected push a trackPageView, so PJAX pages can 
-			//be tracked successfully.
+			// If Google analytics is detected push a trackPageView, so PJAX pages can 
+			// be tracked successfully.
 			if(window._gaq) _gaq.push(['_trackPageview']);
 
-			//Set new title
+			// Set new title
 			document.title = options.title;
 		});
-		
-	}
+	};
 
 	/**
 	 * Request
@@ -294,27 +295,27 @@
 	 * @param callback. Method to call when a page is loaded.
 	 */
 	internal.request = function(location, callback){
-		//Create xmlHttpRequest object.
+		// Create xmlHttpRequest object.
 		try {xmlhttp = window.XMLHttpRequest?new XMLHttpRequest(): new ActiveXObject("Microsoft.XMLHTTP");}  catch (e) { }
-			//Add state listener.
+			// Add state listener.
 			xmlhttp.onreadystatechange = function(){
-				if ((xmlhttp.readyState == 4) && (xmlhttp.status == 200)) {
-					//Success, Return html
+				if ((xmlhttp.readyState === 4) && (xmlhttp.status === 200)) {
+					// Success, Return html
 					callback(xmlhttp.responseText);
-				}else if((xmlhttp.readyState == 4) && (xmlhttp.status == 404 || xmlhttp.status == 500)){
-					//error (return false)
+				}else if((xmlhttp.readyState === 4) && (xmlhttp.status === 404 || xmlhttp.status === 500)){
+					// error (return false)
 					callback(false);
 				}
-			}
-			//Secret pjax ?get param so browser doesnt return pjax content from cache when we dont want it to
-			//Switch between ? and & so as not to break any URL params (Based on change by zmasek https://github.com/zmasek/)
+			};
+			// Secret pjax ?get param so browser doesnt return pjax content from cache when we dont want it to
+			// Switch between ? and & so as not to break any URL params (Based on change by zmasek https://github.com/zmasek/)
 			xmlhttp.open("GET", location + ((!/[?&]/.test(location)) ? '?_pjax' : '&_pjax'), true);
-			//Add headers so things can tell the request is being performed via AJAX.
-			xmlhttp.setRequestHeader('X-PJAX', 'true'); //PJAX header
-			xmlhttp.setRequestHeader('X-Requested-With', 'XMLHttpRequest');//Standard AJAX header.
+			// Add headers so things can tell the request is being performed via AJAX.
+			xmlhttp.setRequestHeader('X-PJAX', 'true'); // PJAX header
+			xmlhttp.setRequestHeader('X-Requested-With', 'XMLHttpRequest');// Standard AJAX header.
 
 			xmlhttp.send(null);
-	}
+	};
 
 	/**
 	 * parseOptions
@@ -325,66 +326,66 @@
 	 * @return false | valid options object
 	 */
 	internal.parseOptions = function(options){
-		//Defaults. (if somthing isn't provided)
+		// Defaults. (if somthing isn't provided)
 		opt = {};
 		opt.history = true;
 		opt.parseLinksOnload = true;
 		opt.smartLoad = true;
 
-		//Ensure a url and container have been provided.
-		if(typeof options.url == 'undefined' || typeof options.container == 'undefined'){
+		// Ensure a url and container have been provided.
+		if(typeof options.url === 'undefined' || typeof options.container === 'undefined'){
 			console.log("URL and Container must be provided.");
 			return false;
 		}
 
-		//Find out if history has been provided
+		// Find out if history has been provided
 		if(typeof options.history === 'undefined'){
-			//use default
+			// use default
 			options.history = opt.history;
 		}else{
-			//Ensure its bool.
-			options.history = (!(options.history == false));
+			// Ensure its bool.
+			options.history = (!(options.history === false));
 		}
 
-		//Parse Links on load? Enabled by default.
-		//(Proccess pages loaded via PJAX and setup PJAX on any links found.)
-		if(typeof options.parseLinksOnload == 'undefined'){
+		// Parse Links on load? Enabled by default.
+		// (Proccess pages loaded via PJAX and setup PJAX on any links found.)
+		if(typeof options.parseLinksOnload === 'undefined'){
 			options.parseLinksOnload = opt.parseLinksOnload;
 		}
 
-		//Smart load (enabled by default.) Trys to ensure the correct HTML is loaded.
-		//If you are certain your backend will only return PJAX ready content this can be disabled
-		//for a slight perfomance boost.
-		if(typeof options.smartLoad == 'undefined'){
+		// Smart load (enabled by default.) Trys to ensure the correct HTML is loaded.
+		// If you are certain your backend will only return PJAX ready content this can be disabled
+		// for a slight perfomance boost.
+		if(typeof options.smartLoad === 'undefined'){
 			options.smartLoad = opt.smartLoad;
 		}
 
-		//Get container (if its an id, convert it to a dom node.)
-		if(typeof options.container == 'string' ) {
+		// Get container (if its an id, convert it to a dom node.)
+		if(typeof options.container === 'string' ) {
 			container = document.getElementById(options.container);
-			if(container == null){
+			if(container === null){
 				console.log("Could not find container with id:"+options.container);
 				return false;
 			}
 			options.container = container;
 		}
 
-		//If everything went ok thus far, connect up listeners
-		if(typeof options.beforeSend == 'function'){
+		// If everything went ok thus far, connect up listeners
+		if(typeof options.beforeSend === 'function'){
 			internal.addEvent(options.container, 'beforeSend', options.beforeSend);
 		}
-		if(typeof options.complete == 'function'){
+		if(typeof options.complete === 'function'){
 			internal.addEvent(options.container, 'complete', options.complete);
 		}
-		if(typeof options.error == 'function'){
+		if(typeof options.error === 'function'){
 			internal.addEvent(options.container, 'error', options.error);
 		}
-		if(typeof options.success == 'function'){
+		if(typeof options.success === 'function'){
 			internal.addEvent(options.container, 'success', options.success);
 		}
-		//Return valid options
+		// Return valid options
 		return options;
-	}
+	};
 
 	/**
 	 * connect
@@ -393,32 +394,32 @@
 	 *
 	 * Can be called in 3 ways.
 	 * Calling as connect(); 
-	 * 		Will look for links with the data-pjax attribute.
+	 *		Will look for links with the data-pjax attribute.
 	 *
 	 * Calling as connect(container_id)
 	 *		Will try to attach to all links, using the container_id as the target.
 	 *
 	 * Calling as connect(container_id, class_name)
-	 * 		Will try to attach any links with the given classname, using container_id as the target.
+	 *		Will try to attach any links with the given classname, using container_id as the target.
 	 *
 	 * Calling as connect({	
 	 *						'url':'somepage.php',
 	 *						'container':'somecontainer',
-	 * 						'beforeSend': function(){console.log("sending");}
+	 *						'beforeSend': function(){console.log("sending");}
 	 *					})
-	 * 		Will use the provided json to configure the script in full (including callbacks)
+	 *		Will use the provided json to configure the script in full (including callbacks)
 	 */
 	this.connect = function(/* options */){
-		//connect();
+		// connect();
 		var options = {};
-		//connect(container, class_to_apply_to)
-		if(arguments.length == 2){
+		// connect(container, class_to_apply_to)
+		if(arguments.length === 2){
 			options.container = arguments[0];
 			options.useClass = arguments[1];
 		}
-		//Either json or container id
-		if(arguments.length == 1){
-			if(typeof arguments[0] == 'string' ) {
+		// Either json or container id
+		if(arguments.length === 1){
+			if(typeof arguments[0] === 'string' ) {
 				//connect(container_id)
 				options.container = arguments[0];
 			}else{
@@ -431,7 +432,7 @@
 		delete options.history;
 		
 		internal.options = options;
-		if(document.readyState == 'complete') {
+		if(document.readyState === 'complete') {
 			internal.parseLinks(document, options);
 		} else {
 			//Dont run until the window is ready.
@@ -440,7 +441,7 @@
 				internal.parseLinks(document, options);
 			});
 		}
-	}
+	};
 	
 	/**
 	 * invoke
@@ -451,31 +452,32 @@
 	 * @param options  
 	 */
 	this.invoke = function(/* options */){
-		//url, container
-		if(arguments.length == 2){
+		// url, container
+		if(arguments.length === 2){
 			options = {};
 			options.url = arguments[0];
 			options.container = arguments[1];
 		}else{
 			options = arguments[0];
 		}
-		//If PJAX isn't supported by the current browser, push user to specified page.
+		// If PJAX isn't supported by the current browser, push user to specified page.
 		if(!internal.is_supported){
 			document.location = options.url;
 			return;	
 		} 
-		//Proccess options
+		// Proccess options
 		options = internal.parseOptions(options);
-		//If everything went ok, activate pjax.
+		// If everything went ok, activate pjax.
 		if(options !== false) internal.handle(options);
-	}
+	};
 
+	// Make object useable
 	var pjax_obj = this;
-	if (typeof define === 'function' && define['amd']) {
-		// register pjax as AMD module
+	if (typeof define === 'function' && define.amd) {
+		// Register pjax as AMD module
 		define( function() {
-            return pjax_obj;
-        });
+			return pjax_obj;
+		});
 	}else{
 		// Make PJAX object accessible in global namespace
 		window.pjax = pjax_obj;

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ A live version of the demo can be viewed here: http://userbag.co.uk/demo/pjax/
 
 ### Usage Instructions
 
-To add pjax to your page, you will need to include the pjax-standalone.js script in to the head of your document.
+To use pjax on your page you will need to include the pjax-standalone.js script in to the head of the page. Alternatly, if the assets for your site are built (using a tool like grunt) pjax standalone can also be installed using bower `bower install pjax-standalone`.
 
 Once done, PJAX can be setup in 3 ways. 
 

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ PJAX-Standalone implements the following callbacks/events:
 * complete - When AJAX request has completed
 * success - When AJAX request has completed successfully
 * error - When AJAX request did not complete successfully (error 404/500 etc)
+* ready - Fired when PJAX completes initial link parsing
 
 The callbacks can be specified either as part of the original pjax.connect method:
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ To use PJAX on your page you will need to include the pjax-standalone.js script 
 Once done, PJAX can be setup in 3 ways. 
 
 #### Option 1
-Give all links a data-pjax attribute specifying where to place the content that gets loaded.:
+Give all links a data-pjax attribute specifying where to place the content that gets loaded:
 
     <a href='page1.php' data-pjax='content'>Page 1</a>
 
@@ -48,38 +48,44 @@ Set all links with a specific class to use a particular container using:
 ```
 	pjax.connect('content', 'pjaxer');
 ```	
+### Options
+
+The PJAX connect method supports the following options:
+
+* useClass - string - Apply PJAX only to links with the provided class.
+* excludeClass - string - If set, PJAX will ignore any link containing the class
+* parseLinksOnload - true|false - Make links in loaded pages use PJAX. Enabled by default.
+* smartLoad - true|false - Ensure returned HTML is correct. Enabled by default.
+* autoAnalytics - true|false - Enabled by default, will attempt to automatically track page views to any detected google analytics trackers.
+* returnToTop - true|false - Enabled by default, scrolls browser window to top of page, when new content is loaded.
 
 ### Callbacks
 
-PJAX-Standalone implements the following callbacks 
+PJAX-Standalone implements the following callbacks/events:
 
 * beforeSend - Called before AJAX request is made
 * complete - When AJAX request has completed
 * success - When AJAX request has completed successfully
 * error - When AJAX request did not complete successfully (error 404/500 etc)
 
-The callbacks are specified as part of the original pjax.connect method:
+The callbacks can be specified either as part of the original pjax.connect method:
 
 	pjax.connect({
 		'container': 'content',
-		'beforeSend': function(){console.log("before send");},
-		'complete': function(){console.log("done!");},
+		'beforeSend': function(e){ console.log("before send"); },
+		'complete': function(e){ console.log("done!"); },
 	});
 
-The PJAX options at the time of an event being triggered can also be accessed via `event.data` within the callback.
+Or by adding your own listener to the specified container
 
-In addition to the callbacks the following options can also be provided to PJAX connect.
+	document.getElementById("my_container").addEventListener('complete', function(event){ console.log(event); }, false);
 
-* useClass - string - Apply PJAX only to links with the provided class.
-* parseLinksOnload - true|false - Make links in loaded pages use PJAX. Enabled by default.
-* smartLoad - true|false - Ensure returned HTML is correct. Enabled by default.
-* autoAnalytics = true|false - Enabled by default, will attempt to automatically track page views to any detected google analytics trackers.
-
+The PJAX options at the time of an event being triggered can be accessed via `event.data`
 
 ### Using PJAX-Standalone programmatically
 
-You can invoke a pjax page load programmatically by calling the pjax.invoke() method.
-At minimum the pjax invoke method must be given a url and container attribute. It can also
+You can invoke a PJAX page load programmatically by calling the pjax.invoke() method.
+At minimum the PJAX invoke method must be given a URL and container attribute. It can also
 be provided with a title, parseLinksOnload setting and any callbacks you wish to use.
 
 	pjax.invoke({url:'page1.php', 'container': 'content'});
@@ -93,11 +99,10 @@ or
 Update your code to return only the main content area when the X-PJAX header is set, while returning the full website layout when it is not.
 	
 	<?php
-	$headers = getallheaders();
-	if(($headers['X-PJAX'] == 'true')){
-		//Output content on its own.
+	if(isset($_SERVER['HTTP_X_PJAX']) && $_SERVER['HTTP_X_PJAX'] == 'true'){
+		// Output content on its own.
 	}else{
-		//Output content with wrapper/layout
+		// Output content with wrapper/layout
 	}
 
 If you are unable to change the server side code or simply do not want to, So long as smartLoad is enabled (which it is by default), PJAX-Standalone will extract the container_divs content from the returned HTML and apply it to the current page meaning PJAX loading will still work as expect (although some of PJAX's performance gains may be lost).

--- a/readme.md
+++ b/readme.md
@@ -5,14 +5,14 @@ The design is loosely based on the original jQuery implementation found at: http
 
 This code is licensed under the MIT License.
 
-This code has been tested in Chrome, Firefox, Opera and IE7,8 and 9. 
-PJAX is supported in Chrome, Firefox and Opera, while in IE the fall backs operate as expected.
+This code has been tested in Chrome, Firefox, Opera and IE7, 8, 9 and 10. 
+PJAX is supported in Chrome, Firefox, IE10+ and Opera, while in older IE versions the fall backs operate as expected.
 
 A live version of the demo can be viewed here: http://userbag.co.uk/demo/pjax/
 
 ### Usage Instructions
 
-To use pjax on your page you will need to include the pjax-standalone.js script in to the head of the page. Alternatly, if the assets for your site are built (using a tool like grunt) pjax standalone can also be installed using bower `bower install pjax-standalone`.
+To use PJAX on your page you will need to include the pjax-standalone.js script in to the head of the page. Alternately, if the assets for your site are built (using a tool like grunt) PJAX standalone can also be installed using bower `bower install pjax-standalone`.
 
 Once done, PJAX can be setup in 3 ways. 
 
@@ -51,12 +51,12 @@ Set all links with a specific class to use a particular container using:
 
 ### Callbacks
 
-PJAX-Standalone impliments the following callbacks 
+PJAX-Standalone implements the following callbacks 
 
-* beforeSend - Called before ajax request is made
-* complete - When ajax request has completed
-* success - When ajax request has completed successfully
-* error - When ajax request did not complet successfully (error 404/500 etc)
+* beforeSend - Called before AJAX request is made
+* complete - When AJAX request has completed
+* success - When AJAX request has completed successfully
+* error - When AJAX request did not complete successfully (error 404/500 etc)
 
 The callbacks are specified as part of the original pjax.connect method:
 
@@ -66,11 +66,15 @@ The callbacks are specified as part of the original pjax.connect method:
 		'complete': function(){console.log("done!");},
 	});
 
+The PJAX options at the time of an event being triggered can also be accessed via `event.data` within the callback.
+
 In addition to the callbacks the following options can also be provided to PJAX connect.
 
 * useClass - string - Apply PJAX only to links with the provided class.
 * parseLinksOnload - true|false - Make links in loaded pages use PJAX. Enabled by default.
 * smartLoad - true|false - Ensure returned HTML is correct. Enabled by default.
+* autoAnalytics = true|false - Enabled by default, will attempt to automatically track page views to any detected google analytics trackers.
+
 
 ### Using PJAX-Standalone programmatically
 
@@ -96,7 +100,7 @@ Update your code to return only the main content area when the X-PJAX header is 
 		//Output content with wrapper/layout
 	}
 
-If you are unable to change the backend code, or simply do not want to. So long as smartLoad is enabled (which it is by default), PJAX-Standalone will extract the container_divs content from the returned HTML and apply it to the current page meaning PJAX loading will still work as expect (although some of PJAX's performance gains may be lost).
+If you are unable to change the server side code or simply do not want to, So long as smartLoad is enabled (which it is by default), PJAX-Standalone will extract the container_divs content from the returned HTML and apply it to the current page meaning PJAX loading will still work as expect (although some of PJAX's performance gains may be lost).
 
 
 	

--- a/test/index.php
+++ b/test/index.php
@@ -4,30 +4,46 @@ $title = 'PJAX-Standalone';
 $contents = '
 	<h1>PJAX-Standalone</h1>
 	
-	<p>Pjax-Standalone is a standalone implimention of defunkt\'s original
-	<a href=\'https://github.com/defunkt/jquery-pjax\'>JQuery-PJax</a> plugin which has no dependencies and thus can be dropped in to, and used, on any webpage
-	you wish, regardless of the JavaScript framework employed (or even if none is used at all).
+	<p>
+		Pjax-Standalone is a standalone implementation of defunkt\'s original
+		<a href=\'https://github.com/defunkt/jquery-pjax\'>jQuery-PJAX</a> plugin. With no external dependencies, PJAX-Standalone can 
+		be dropped into and used on any website, regardless of the JavaScript frameworks in use.
+	</p>
+	<h3>About</h3>
+	<p>
+		PJAX Standalone is easy to set up and get working with both new and existing websites. Adding the PJAX-Standalone 
+		JavaScript to the head of your website and calling <code>pjax.connect("id_of_container");</code> is all thats needed
+		to get it working.
 	</p>
 	<p>
-	Like its counterpart, PJAX-Standalone is designed to be incredibly easy to setup and add in
-	to existing web pages. In many sites nothing more will be needed than inclusion of the script in to the page
-	and a single call to "pjax.connect(\'my_content_div\');"
-
-
+		By default PJAX-Standalone uses it\'s "smartload" feature in order to work with existing with pages with no server side support for PJAX. If 
+		your server side code is configured to work with PJAX (thus only returning the content needed for rendering) this feature can be 
+		disabled for even more performance gains.</p>
+	<p>
+		<strong>Is PJAX-Standlone worth having on my site?</strong><br/>
+		PJAX provides the most benefit if your website design comprises primarily of one main content area, surrounded by a 
+		wrapper (header, footer, aside) that rarely change. Since PJAX only ever has to reload the main container area\'s content, assets such as CSS, JavaScript, images and others will only be loaded once.
 	</p>
 
+	<p>
+		<strong>How customizable is PJAX-Standalone</strong><br/>
+		PJAX-Standalone fires a number of events, which can be used to extend its native functionality. Additionally
+		a number of additional options can be specified in the connect method, in order to further configure how PJAX-Standalone functions. 
+		Documentation on the events and options available in PJAX can be seen in the <a href="https://github.com/thybag/PJAX-Standalone/t">github readme</a>.
+	</p>
+	<a name="what"></a>
 	<h3>What is PJAX</h3>
 	<p>
-	PJAX (Push-state AJAX) for the most part is a speed optimisation. 
-	It allows users to navigate your website without ever having to reload 
-	the entire page (or wait for the browser to redraw the main layout)
-
-	while still preserving the page titles, permalinks and full back button functionality. Additionally, if 
-	a browser does not support the PJAX feature set, the links will simply work as normal, allowing
-	it to degrade gracefully without ever impacting the functionality of a website.
+		PJAX (Push-state AJAX) is a performance optimization, allowing users to browse websites without the overhead of 
+		reloading assets such as CSS & images each time a web page is loaded.
 	</p>
-
-	
+	<p>
+		PJAX works by using AJAX to "load" pages on behalf of the user, then dynamically swapping the contents of
+		the "container" for the newly loaded content from the link the user clicked. Unlike older AJAX solution\'s PJAX
+		fully preserves permalinks and back button functionality. Using progressive enhancement, PJAX will 
+		seamlessly fall back to loading pages in the normal way in older browsers, while newer browsers can make use
+		of the improved performance.
+	</p>	
 ';
 
 if(isset($_SERVER['HTTP_X_PJAX']) && $_SERVER['HTTP_X_PJAX'] == 'true'){

--- a/test/page1.php
+++ b/test/page1.php
@@ -1,11 +1,15 @@
 <?php
 
-$title = 'Page 1: Hello Tester';
+$title = 'Demo 1: Is it working?';
 $contents = '
-	<h1>Page 1 - Actual time.</h1>
+	<h1>Demo 1 - Actual time.</h1>
 	<p>The real time is: <strong>'.date('l jS \of F Y h:i:s A').'</strong>.</p>
-	<p>If the above time does not match that of the "Loaded at" then this page was requested via PJAX.</p>
-	<p>Currently this page is simply returning the full HTML version of itself rather than PJAX ready content, although smartLoad fixes this seamlessly.</p>
+	<p>If the above time does not match that of the "Loaded at" (section on the right) then this page was successfully requested via PJAX.</p>
+	<p>Currently this page is simply returning the full HTML version of itself rather than PJAX ready content, meaning smartLoad is being used to seamlessly extract only the required content.</p>
+
+	<h3>Invoke</h3>
+	<p>The below button uses the <code>pjax.invoke()</code> method to load the home page (via PJAX if it is supported).</p>
+	<button onclick="pjax.invoke(\'index.php\', \'content\');" class="btn">Try me</button>
 ';
 
 //Page 1 returns the full HTML, not the PJAX content and is then correct by the smartLoad feature.

--- a/test/page2.php
+++ b/test/page2.php
@@ -2,7 +2,18 @@
 $title = 'Page 2: Test data';
 $contents = '
 	<h1>Page 2 - Test data</h1>
-	<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+	<p>Nunc dui massa, <a href="#jump">jump to a section</a> tincidunt non interdum id, <a href="http://local.proj/pjax-standalone/test/page3.php#jump_link_not_same_page">on page 3</a>iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+
+<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+<a id="jump"></a><h3>A section</h3>
+<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+
+<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+ 
+ <button onclick="pjax.invoke(\'index.php\', \'content\');"> go home (test invoke)</button>
 ';
 
 if(isset($_SERVER['HTTP_X_PJAX']) && $_SERVER['HTTP_X_PJAX'] == 'true'){

--- a/test/page2.php
+++ b/test/page2.php
@@ -1,19 +1,29 @@
 <?php
-$title = 'Page 2: Test data';
+$title = 'Demo 2 - Jump links';
 $contents = '
-	<h1>Page 2 - Test data</h1>
-	<p>Nunc dui massa, <a href="#jump">jump to a section</a> tincidunt non interdum id, <a href="http://local.proj/pjax-standalone/test/page3.php#jump_link_not_same_page">on page 3</a>iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+	<h1>Demo 2 - Jump links</h1>
+
+	<p>PJAX will automatically ignore jump links found within the same document, so clicking <a href="#hi1">here</a> to
+	 jump to "heading of interest" will not trigger a page reload. But, clicking <a href="index.php#what">this</a> (a link to the "What is PJAX" 
+	 	section on the home page) will.</p>
+
+	<p>If PJAX is unable to load a link <a href="broken page">such as this broken one</a>, the link will be ignored (although the error event will be fired). The demo page is set up to log messages to the 
+	browser console whenever a success, ready or error event is fired.</p>
+
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tempor turpis magna, eu placerat odio consectetur vel. In sed arcu vel neque interdum feugiat. Suspendisse non nisl libero. Duis facilisis, libero vitae scelerisque mollis, augue mi sodales mauris, volutpat congue tortor elit ut magna. Sed quis tincidunt diam. Fusce eget lacinia nisi, sit amet tincidunt elit. Nam rutrum tortor eget enim rhoncus, convallis semper sem tincidunt.</p>
+
+<p>Vestibulum non risus ut metus porta consectetur eget sit amet tellus. Morbi ut turpis auctor, euismod sapien nec, sollicitudin augue. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vitae commodo lorem. In quis dui lobortis, adipiscing justo vel, feugiat augue. Integer tincidunt ultrices nulla, egestas venenatis eros hendrerit sit amet. Proin ornare orci sit amet magna laoreet vehicula. Nunc consectetur mi at cursus porta. Praesent dictum, magna vel mollis sodales, justo sem sagittis tortor, nec tempor diam ligula sit amet arcu. Vivamus dignissim elementum diam ut rutrum. Donec nec tortor at leo suscipit mattis. Phasellus neque nisi, rutrum eu metus id, aliquet dapibus ante. Aliquam ac metus a ligula scelerisque viverra ac sit amet eros.</p>
+
+<a name="hi1"></a>
+<h3>Heading of interest</h3>
+<p>Sed ut magna a lorem convallis imperdiet. In hac habitasse platea dictumst. Mauris a fermentum libero, a interdum magna. Sed vestibulum lectus odio, at gravida dui accumsan vehicula. Cras eget magna eget orci aliquet fringilla. Vestibulum lacinia commodo euismod. Ut eget scelerisque mi. Aenean faucibus et neque et accumsan. Aliquam non neque sed ante hendrerit laoreet non ut nibh.</p>
+
+<p>Integer massa erat, lacinia quis felis eget, sodales hendrerit ante. Donec adipiscing arcu elit, id suscipit lacus malesuada id. Quisque nec metus eget massa sollicitudin pulvinar nec in nibh. Nunc nec ultricies lacus. Quisque est nibh, pharetra eget lacus at, aliquam adipiscing eros. Nulla sagittis nunc at euismod congue. Cras a ipsum in eros pharetra iaculis. Cras quis lorem vel magna eleifend sagittis. Maecenas leo lectus, feugiat in lorem ac, imperdiet mollis tellus. Mauris sollicitudin vehicula dui. Nunc sodales lacus vel ipsum consequat, non iaculis augue euismod. Integer facilisis sagittis urna vitae congue. Morbi luctus vehicula scelerisque. Aliquam nisi dolor, consequat ac ante eu, aliquam viverra sem.</p>
+<h3>Heading of interest 2</h3>
+<p>Cras purus augue, vehicula eu cursus id, vehicula nec ante. Suspendisse ac lectus vitae est pellentesque faucibus sit amet vel erat. Maecenas sem leo, tempus ut tincidunt at, posuere nec massa. Nullam commodo nulla et lobortis rhoncus. Integer aliquam augue et justo laoreet tristique eu eu mauris. Praesent ut urna sed augue auctor ornare at vitae nisl. Aliquam ultrices ante at sapien porta, non semper lacus pellentesque. Aenean placerat eleifend orci eget viverra. Etiam faucibus elit sed sem vestibulum euismod. Nunc blandit sem lorem, ut accumsan sapien consectetur a. Pellentesque sagittis metus eu placerat posuere. Pellentesque eget ultrices eros, ac tincidunt leo. Aenean sagittis mollis interdum.</p>
 
 <p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
-<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
-<a id="jump"></a><h3>A section</h3>
-<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
-<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
-<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
 
-<p>Nunc dui massa, tincidunt non interdum id, iaculis vitae tellus. Donec et lectus at neque consectetur facilisis nec eget ante. Proin egestas volutpat semper. Mauris aliquam metus eget nibh tincidunt luctus sit amet id mauris. Aliquam vitae ipsum diam, at rutrum arcu. Suspendisse potenti. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
- 
- <button onclick="pjax.invoke(\'index.php\', \'content\');"> go home (test invoke)</button>
 ';
 
 if(isset($_SERVER['HTTP_X_PJAX']) && $_SERVER['HTTP_X_PJAX'] == 'true'){

--- a/test/page3.php
+++ b/test/page3.php
@@ -1,19 +1,19 @@
 <?php
-$title = 'Page 3 - With a drunk cat.';
+$title = 'Page 3 - Cat';
 $contents = '
-	<img src="img/cat.jpg" alt="Picture of a drunk cat" style="width:50%;float:right">
-	<h1>Page 3 - Drunk Cat.</h1>
+	
+	<h1>Demo 3 - Cat picture.</h1>
 	<p>
-		Welcome to demo page 3. Here we see a picture of a drunk cat 
-		(which is totally 100% not at all staged... *shifty eyes*).
-	</p>
-	<p>
-		You\'ll see that along with the url and webpage content, the title has also been updated.
+		You\'ll see that along with the URL and container content, the title has also been updated.
 		Using PJAX you can even give pages custom titles, for example
 
 		<a href="page2.php" data-title="Custom title!">this link</a>
 		 will open page 2  with the title "Custom title!".
 	</p>
+	<hr/>
+	<h3>A picture of a cat.</h3>
+	<img src="img/cat.jpg" alt="Picture of a drunk cat" />
+	<p>There really isn\'t a good reason for this...</p>
 ';
 
 if(isset($_SERVER['HTTP_X_PJAX']) && $_SERVER['HTTP_X_PJAX'] == 'true'){

--- a/test/wrapper.php
+++ b/test/wrapper.php
@@ -6,115 +6,65 @@
 
 	<script type="text/javascript" src='../pjax-standalone.js'></script> 
 	<script type='text/javascript'>
-		//PJAX links!
+		// Ensure console is defined
+		if(typeof console === 'undefined') console = {"log":function(m){}};
 
+		// PJAX links!
 		pjax.connect({
 			'container': 'content',
-			'beforeSend': function(event){ 
-				console.log("before send");
-			},
 			'success': function(event){
 				var url = (typeof event.data !== 'undefined') ? event.data.url : '';
-				console.log("Sucessfully loaded "+ url);
+				console.log("Successfully loaded "+ url);
+			},
+			'error': function(event){
+				var url = (typeof event.data !== 'undefined') ? event.data.url : '';
+				console.log("Could not load "+ url);
+			},
+			'ready': function(){
+				console.log("PJAX loaded!");
 			}
 		});
-		//pjax.connect('content', 'pjaxer');
-		//pjax.connect('content');
-		//pjax.connect();
-		
+		// pjax.connect('content', 'pjaxer');
+		// pjax.connect('content');
+		// pjax.connect();
+
 	</script>
-
 	<!-- Local styles for Demo -->
-	<style type='text/css'>
-		body{
-			font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; 
-			font-size:0.9em; 
-			margin:0;padding:0;
-		}
-		.main .header {
-			background-color:#222;
-			color:#fff;
-			padding:8px; 
-		}
-		.main .header .heading{
-			width:880px; 
-			margin:0 auto;
-		}
-		.main .header h1 {
-			margin:5px 0;
-		}
-		.main .header a {
-			color:#fff;
-		}
-
-		.body {
-			padding:0 0px;
-			background-color:#fff;
-		}
-		a {color:#000;}
-		.body .seperator{
-			background-color:#222;
-			padding:4px;
-			clear:both;
-			color:#fff;
-			margin:5px 0;
-			font-weight:bold;
-		}
-		.body .nav {
-			padding:4px;
-			background-color:#999;
-		}
-		.body .links {		
-			margin:0 auto;
-			width:900px;
-		}
-		.body .links a {
-			padding:8px;
-		}
-		#content {
-			width:900px; margin:0 auto;
-		}
-		.get_button {
-			background:#666;
-			padding:10px 15px;
-			text-decoration:none;
-			border-radius:4px;
-			float:right;
-			margin-top:8px;
-			background: -webkit-gradient(linear,left top,left bottom, from(#666), to(#444));
-			background: -moz-linear-gradient(top,#666,#444);
-			-webkit-box-shadow: inset 0px 1px 1px 0px #888, 0px 2px 2px 0px rgba(0,0,0,0.5);
-			-moz-box-shadow: inset 0px 1px 1px 0px #888, 0px 2px 2px 0px rgba(0,0,0,0.5);
-		}
-		.get_button:hover {
-			background: -webkit-gradient(linear,left top,left bottom, from(#444), to(#555));
-			background: -moz-linear-gradient(top,#444,#555);
-		}
-	</style>
+	<link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/bootswatch/3.0.3/cosmo/bootstrap.min.css" media="screen" />
+	
 </head>
 <body>
-	<div class='main'>
-		<div class='header'>
-			
-			<div class='heading'>
-				<div class='get'><a target='_blank' href='https://github.com/thybag/PJAX-Standalone' class='get_button' >Get the Source</a></div>
-				<h1>PJAX-Standalone Test Page</h1>
-				Loaded at: <?php echo date('l jS \of F Y h:i:s A'); ?>
-			</div>
+	<div class="navbar navbar-default navbar-static-top">
+		<div class="navbar-header">
+			<a href="." class="navbar-brand">PJAX Standalone</a>
 		</div>
-		<div class='body'>
-			<div class='nav'>
-				<div class='links'>
-					<a href='.' data-pjax='content'>Home</a>
-					<a href='page1.php' data-pjax='content'>Page 1</a>
-					<a href='page2.php' data-pjax='content'>Page 2</a>
-					<a href='page3.php?test=test'>Page 3</a>
-				</div>
-			</div>
-			<div id='content'>
-				<?php echo $contents; ?>
-			</div>
+	 	<ul class="nav navbar-nav" style='margin-left:20px;'>
+			<li><a href='.' data-pjax='content'>Home</a></li>
+			<li><a href='page1.php' data-pjax='content'>demo 1</a></li>
+			<li><a href='page2.php' data-pjax='content'>demo 2</a></li>
+			<li><a href='page3.php?test=test' class='no'>demo 3</a></li>
+		</ul>
+	</div>
+	<div class='container'>
+		<div id='content' class='col-sm-8'>
+			<?php echo $contents; ?>			
+		</div>
+		<div class='col-sm-4'>
+			<p class='well'><strong>Loaded at:</strong><br/> <?php echo date('l jS \of F Y h:i:s A'); ?></p>
+			<p>
+				<a href='https://github.com/thybag/PJAX-Standalone' class='btn btn-block btn-primary'>Get the Source</a>
+			</p>
+			<p>PJAX-Standalone is licensed under the MIT License.</p>
+
+			<p>Install with <a href='http://bower.io/'>bower</a>:</p>
+			<p><code>bower install pjax-standalone</code></p>
+
+			<hr />
+			<p>Full documentation for using PJAX-Standalone can be found in the <a href='https://github.com/thybag/PJAX-Standalone'>github readme file</a>.</p>
 		</div>
 	</div>
+	<script>
+		//document.getElementById("content").addEventListener('complete', function(e){ console.log(e); }, false);
+	</script>
 </body>
 </html>

--- a/test/wrapper.php
+++ b/test/wrapper.php
@@ -7,10 +7,16 @@
 	<script type="text/javascript" src='../pjax-standalone.js'></script> 
 	<script type='text/javascript'>
 		//PJAX links!
+
 		pjax.connect({
 			'container': 'content',
-			'beforeSend': function(){console.log("before send");},
-			'complete': function(){console.log("done!");}
+			'beforeSend': function(event){ 
+				console.log("before send");
+			},
+			'success': function(event){
+				var url = (typeof event.data !== 'undefined') ? event.data.url : '';
+				console.log("Sucessfully loaded "+ url);
+			}
 		});
 		//pjax.connect('content', 'pjaxer');
 		//pjax.connect('content');


### PR DESCRIPTION
New:
- Auto Analytics is now optional & can be disabled via settings
- Auto Analytics now supports Universal Analytics
- Added excludeClass option (to exclude certain links from pjax loading)
- Add returnToTop option to configure if pages loaded via pjax should return the browser scroll position back to the top.
- Add "ready" event, fired on pjax load
- PJAX options for page load made available via event.data in callbacks
- Prettied up and improved test site (using bootstrap theme) + updated info

Bug fixes:
- Fix handle running attach in incorrect page scope, resulting in some #hash urls being ignored when they shouldn't be
- Fix control click not opening pjax links new window
- Fix smartload titles being overwritten
- Fix custom titles not displaying on back button
- Fix pages not default scrolling to the top on load
- Fix broken pages causing error in PJAX-Standalone code

Re-factoring;
- none pushstate browser fall backs now operate in cleaner way (not mixed in with main code)
- Lots of spelling corrections in comments
- Comparisons now done directly rather than via type conversion == vs ===
- Fix multiple jslint issues
- Make parseOptions code more DRY
- Improve readme docs
