### PR TITLE
smartLoad title extraction fixed.

### DIFF
--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -238,14 +238,11 @@
 	 */
 	internal.smartLoad = function(html, options) {
 		// Grab the title if there is one
-		var title = html.getElementsByTagName('title')[0].innerHTML;
+		var title = html.getElementsByTagName('title')[0];
 		if(title)
-			document.title = title;
+			document.title = title.innerHTML;
 
-		// Going by caniuse all browsers that support the pushstate API also support querySelector's
-		// see: http://caniuse.com/#search=push 
-		// see: http://caniuse.com/#search=querySelector
-		var container = html.querySelector("#" + options.container.id);
+		var container = document.getElementById(options.container.id);
 		if(container !== null) return container;
 
 		// If our container was not found, HTML will be returned as is.

--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -242,7 +242,10 @@
 		if(title)
 			document.title = title.innerHTML;
 
-		var container = document.getElementById(options.container.id);
+		// Going by caniuse all browsers that support the pushstate API also support querySelector's
+		// see: http://caniuse.com/#search=push
+		// see: http://caniuse.com/#search=querySelector
+		var container = html.querySelector("#" + options.container.id);
 		if(container !== null) return container;
 
 		// If our container was not found, HTML will be returned as is.


### PR DESCRIPTION
`internal.smartLoad` fails if there’s no `<title>` element. This PR fixes it.

It’s usually not recommended to change different things in one PR, but I also changed the `.querySelector` call in the same function with `document.getElementById` which is faster and supported everywhere. (update: it was a mistake, it has been reverted)
