### PR TITLE
Update pjax-standalone.js

### DIFF
--- a/pjax-standalone.js
+++ b/pjax-standalone.js
@@ -151,6 +151,9 @@
 
 		// Add link HREF to object
 		options.url = node.href;
+		
+		// Add link reference to object allowing beforeSend access to clicked node
+		options.node = node;
 
 		// If PJAX data is specified, use as container
 		if(node.getAttribute('data-pjax')) {


### PR DESCRIPTION
I was hoping a reference to the clicked node was available in beforeSend (I wanted to add a class to the link) so added it here. Available in the event passed to beforeSend as e.data.node.
